### PR TITLE
Accept the "unix_socket_path" argument

### DIFF
--- a/redisdl.py
+++ b/redisdl.py
@@ -6,8 +6,23 @@ except ImportError:
     import simplejson as json
 import redis
 
-def dumps(host='localhost', port=6379, password=None, db=0, pretty=False):
-    r = redis.Redis(host=host, port=port, password=password, db=db)
+def client(host='localhost', port=6379, password=None, db=0,
+                 unix_socket_path=''):
+    if unix_socket_path:
+        r = redis.Redis(unix_socket_path=unix_socket_path,
+                        password=None,
+                        db=db)
+    else:
+        r = redis.Redis(host=host,
+                        port=port,
+                        password=password,
+                        db=db)
+    return r
+
+def dumps(host='localhost', port=6379, password=None, db=0, pretty=False,
+          unix_socket_path=''):
+    r = client(host=host, port=port, password=password, db=db,
+               unix_socket_path='')
     kwargs = {}
     if not pretty:
         kwargs['separators'] = (',', ':')
@@ -20,13 +35,15 @@ def dumps(host='localhost', port=6379, password=None, db=0, pretty=False):
         table[key] = {'type': type, 'value': value}
     return encoder.encode(table)
 
-def dump(fp, host='localhost', port=6379, password=None, db=0, pretty=False):
+def dump(fp, host='localhost', port=6379, password=None, db=0, pretty=False,
+         unix_socket_path=''):
     if pretty:
         # hack to avoid implementing pretty printing
         fp.write(dumps(host=host, port=port, password=password, db=db, pretty=pretty))
         return
     
-    r = redis.Redis(host=host, port=port, password=password, db=db)
+    r = client(host=host, port=port, password=password, db=db,
+               unix_socket_path='')
     kwargs = {}
     if not pretty:
         kwargs['separators'] = (',', ':')
@@ -67,8 +84,10 @@ def _reader(r, pretty):
             raise UnknownTypeError("Unknown key type: %s" % type)
         yield key, type, value
 
-def loads(s, host='localhost', port=6379, password=None, db=0, empty=False):
-    r = redis.Redis(host=host, port=port, password=password, db=db)
+def loads(s, host='localhost', port=6379, password=None, db=0, empty=False,
+          unix_socket_path=''):
+    r = client(host=host, port=port, password=password, db=db,
+               unix_socket_path='')
     if empty:
         for key in r.keys():
             r.delete(key)
@@ -79,9 +98,10 @@ def loads(s, host='localhost', port=6379, password=None, db=0, empty=False):
         value = item['value']
         _writer(r, key, type, value)
 
-def load(fp, host='localhost', port=6379, password=None, db=0, empty=False):
+def load(fp, host='localhost', port=6379, password=None, db=0, empty=False,
+         unix_socket_path=''):
     s = fp.read()
-    loads(s, host, port, password, db, empty)
+    loads(s, host, port, password, db, empty, unix_socket_path)
 
 def _writer(r, key, type, value):
     r.delete(key)


### PR DESCRIPTION
I see that among the options of redisdl there is a "--socket"... which however doesn't seem to be taken into consideration.

This patch enables redisdl to use unix sockets, taking the same argument, "unix_socket_path", accepted by redis.Redis(). (It does still _not_ enable the command line switch)
