### PR TITLE
Make writes through a pipeline to reduce waiting times

### DIFF
--- a/redisdl.py
+++ b/redisdl.py
@@ -108,11 +108,23 @@ def loads(s, host='localhost', port=6379, password=None, db=0, empty=False,
         for key in r.keys():
             r.delete(key)
     table = json.loads(s)
+    counter = 0
     for key in table:
+        # Create pipeline:
+        if not counter:
+            p = r.pipeline(transaction=False)
         item = table[key]
         type = item['type']
         value = item['value']
-        _writer(r, key, type, value)
+        _writer(p, key, type, value)
+        # Increase counter until 10 000...
+        counter = (counter + 1) % 10000
+        # ... then execute:
+        if not counter:
+            p.execute()
+    if counter:
+        # Finally, execute again:
+        p.execute()
 
 def load(fp, host='localhost', port=6379, password=None, db=0, empty=False,
          unix_socket_path=None):


### PR DESCRIPTION
Just try to load some json with and without this patch applied (and measure the time needed for the operation) ;-)

Something analogous should be doable for dumping too (the gain in speed should be, in relative terms, even larger).
