### PR TITLE
Use unicode for io.StringIO, ijson should be optional

### DIFF
--- a/tests/module_test.py
+++ b/tests/module_test.py
@@ -8,6 +8,13 @@ try:
 except ImportError:
     from StringIO import StringIO
 
+try:
+    import ijson as ijson_root
+    have_streaming_load = True
+except ImportError:
+    have_streaming_load = False
+
+
 class ModuleTest(unittest.TestCase):
     def setUp(self):
         import redis
@@ -56,37 +63,40 @@ class ModuleTest(unittest.TestCase):
         self.assertEqual(util.b('\xd0\x9c\xd0\xbe\xd1\x81\xd0\xba\xd0\xb2\xd0\xb0'), value)
 
     def test_load_stringio_python_backend_global(self):
-        self.assertTrue(redisdl.have_streaming_load)
+        if have_streaming_load:
+            self.assertTrue(redisdl.have_streaming_load)
         redisdl.streaming_backend = 'python'
         
         dump = '{"key":{"type":"string","value":"hello, world"}}'
-        io = StringIO(dump)
+        io = StringIO(unicode(dump))
         redisdl.load(io)
         value = self.r.get('key')
         self.assertEqual('hello, world', value.decode('ascii'))
 
     def test_load_stringio_python_backend_local(self):
-        self.assertTrue(redisdl.have_streaming_load)
+        if have_streaming_load:
+            self.assertTrue(redisdl.have_streaming_load)
         
         dump = '{"key":{"type":"string","value":"hello, world"}}'
-        io = StringIO(dump)
+        io = StringIO(unicode(dump))
         redisdl.load(io, streaming_backend='python')
         value = self.r.get('key')
         self.assertEqual('hello, world', value.decode('ascii'))
 
     def test_load_stringio_no_backend(self):
-        self.assertTrue(redisdl.have_streaming_load)
+        if have_streaming_load:
+            self.assertTrue(redisdl.have_streaming_load)
         redisdl.streaming_backend = None
         
         dump = '{"key":{"type":"string","value":"hello, world"}}'
-        io = StringIO(dump)
+        io = StringIO(unicode(dump))
         redisdl.load(io)
         value = self.r.get('key')
         self.assertEqual('hello, world', value.decode('ascii'))
 
     def test_load_stringio_lump(self):
         dump = '{"key":{"type":"string","value":"hello, world"}}'
-        io = StringIO(dump)
+        io = StringIO(unicode(dump))
         redisdl.load_lump(io)
         value = self.r.get('key')
         self.assertEqual('hello, world', value.decode('ascii'))


### PR DESCRIPTION
- [x] Unit tests were failing when `StringIO` is imported from `io` module - which requires non-string.
- [x] Unit tests do not reflect the fact that `ijson` module is optional. Few test cases assumes that a user has `ijson` module installed.