### PR TITLE
[Add] Automatically install binaries `redis-dump`/`redis-load`

### DIFF
--- a/redisdl.py
+++ b/redisdl.py
@@ -329,7 +329,7 @@ def _writer(r, key, type, value):
     else:
         raise UnknownTypeError("Unknown key type: %s" % type)
 
-if __name__ == '__main__':
+def main():
     import optparse
     import os.path
     import re
@@ -454,3 +454,7 @@ if __name__ == '__main__':
             parser.print_help()
             exit(4)
         do_load(options, args)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,16 @@ setup(name=package_name,
     author_email='oleg@bsdpower.com',
     url='http://github.com/p/redis-dump-load',
     py_modules=['redisdl'],
+    install_requires=['redis'],
     data_files=[
         (doc_dir, data_files),
     ],
+    entry_points={
+        'console_scripts': [
+            'redis-load = redisdl:main',
+            'redis-dump = redisdl:main',
+        ],
+    },
     license="BSD",
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This pull request automatically creates the binaries `redis-dump` and `redis-load` when installing the package (e.g. via `pip install`). The binaries are then immediately available to the user on the command-line:

    > pip install redis-dump-load
    > redis-dump
    ... output ...