### PR TITLE
fix ttl calculate error

### DIFF
--- a/redisdl.py
+++ b/redisdl.py
@@ -162,7 +162,6 @@ def dump(fp, host='localhost', port=6379, password=None, db=0, pretty=False,
         type = encoder.encode(type)
         value = encoder.encode(value)
         if ttl:
-            ttl = encoder.encode(ttl)
             expireat = _time.time() + ttl
             item = '%s:{"type":%s,"value":%s,"ttl":%f,"expireat":%f}' % (
                 key, type, value, ttl, expireat)
@@ -359,14 +358,14 @@ def ijson_top_level_items(file, local_streaming_backend):
 class TextWrapper(object):
     def __init__(self, fp):
         self.fp = fp
-        
+
     def read(self, *args, **kwargs):
         return self.fp.read(*args, **kwargs).decode()
 
 class BytesWrapper(object):
     def __init__(self, fp):
         self.fp = fp
-        
+
     def read(self, *args, **kwargs):
         return self.fp.read(*args, **kwargs).encode('utf-8')
 


### PR DESCRIPTION
when i dump redis instance without -y option, I received this:

```
Traceback (most recent call last):
  File "redisdl.py", line 614, in <module>
    main()
  File "redisdl.py", line 605, in main
    do_dump(options)
  File "redisdl.py", line 526, in do_dump
    dump(output, **kwargs)
  File "redisdl.py", line 167, in dump
    expireat = _time.time() + ttl
TypeError: unsupported operand type(s) for +: 'float' and 'str'
```