### PR TITLE
Do not require argument for --empty with redis-load.

### DIFF
--- a/redisdl.py
+++ b/redisdl.py
@@ -591,7 +591,7 @@ def main():
         parser.add_option('-E', '--encoding', help='set encoding to use while decoding data from redis', default='utf-8')
     elif help == LOAD:
         parser.add_option('-d', '--db', help='load into DATABASE (0-N, default 0)')
-        parser.add_option('-e', '--empty', help='delete all keys in destination db prior to loading')
+        parser.add_option('-e', '--empty', help='delete all keys in destination db prior to loading', action='store_true')
         parser.add_option('-E', '--encoding', help='set encoding to use while encoding data to redis', default='utf-8')
         parser.add_option('-B', '--backend', help='use specified streaming backend')
         parser.add_option('-A', '--use-expireat', help='use EXPIREAT rather than TTL/EXPIRE', action='store_true')


### PR DESCRIPTION
This was missing the action so it was expecting an argument.