### PR TITLE
[.gitignore] Ignore directories generated from building Python 3 wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /MANIFEST
 /build
 /dist
+.eggs/
+*.egg-info/


### PR DESCRIPTION
Ignore the following directories which are generated when building a Python 3 wheel package:
- .eggs/
- *.egg-info/