### PR TITLE
#62 accept ttl of -1 from redis-py 3.x

### DIFF
--- a/redisdl.py
+++ b/redisdl.py
@@ -55,12 +55,17 @@ class RedisWrapper(redis.Redis):
     def pttl_or_ttl(self, key):
         if self.have_pttl:
             pttl = self.pttl(key)
-            if pttl is None:
+            if pttl is None or pttl == -1:
                 return None
             else:
                 return float(pttl) / 1000
         else:
-            return self.ttl(key)
+            ttl = self.ttl(key)
+            if ttl is None or ttl == -1:
+                return None
+            else:
+                return ttl
+
 
     def pttl_or_ttl_pipeline(self, p, key):
         if self.have_pttl:
@@ -69,7 +74,7 @@ class RedisWrapper(redis.Redis):
             return p.ttl(key)
 
     def decode_pttl_or_ttl_pipeline_value(self, value):
-        if value is None:
+        if value is None or value == -1:
             return None
         if self.have_pttl:
             return float(value) / 1000


### PR DESCRIPTION
in dump rdb data of redisdl, TTL/PTTL = -1 was not handled. This commit add handling for redis return -1 value.