### PR TITLE
Fix zadd syntax and add support for dealing with partially corrupted datasets

### DIFF
--- a/redisdl.py
+++ b/redisdl.py
@@ -484,7 +484,7 @@ def _writer(r, p, key, type, value, ttl, expireat, use_expireat):
             p.sadd(key, element)
     elif type == 'zset':
         for element, score in value:
-            p.zadd(key, element, score)
+            p.zadd(key, {element: float(score)})
     elif type == 'hash':
         p.hmset(key, value)
     elif type is None:


### PR DESCRIPTION
## zadd
The zadd call was using an incorrect variable scheme. [Reference](https://redis-py.readthedocs.io/en/stable/commands.html#redis.commands.core.CoreCommands.zadd)
For redis-py 4.4 the existing function parameters were invalid, I suspect this was changed at some point in the past.

### recommendation
Assuming my presumption is correct, it should be possible to prevent such problems caused by API changes from arising in the future by specifying the version (or version range) of the redis-py (redis) dependency.

## corrupted data
I was dealing with an old legacy dataset which had null entries for types and values, with these changes such entries are ignored instead of causing an error.